### PR TITLE
Operator타입에 대한 수정

### DIFF
--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -12,17 +12,13 @@ enum Operator: Character, CaseIterable, CalculateItem {
     case divide = "÷"
     case multiply = "×"
 
-    func calculate(lhs: Double, rhs: Double) throws -> Double {
+    func calculate(lhs: Double, rhs: Double) -> Double {
         switch self {
         case .add:
             return add(lhs: lhs, rhs: rhs)
         case .subtract:
             return subtract(lhs: lhs, rhs: rhs)
         case .divide:
-            if rhs == 0 {
-                throw OperationError.divideByZeroError
-            }
-            
             return divide(lhs: lhs, rhs: rhs)
         case .multiply:
             return multiply(lhs: lhs, rhs: rhs)
@@ -30,18 +26,18 @@ enum Operator: Character, CaseIterable, CalculateItem {
     }
     
     private func add(lhs: Double, rhs: Double) -> Double {
-        return NSDecimalNumber(decimal: (Decimal(lhs) + Decimal(rhs))).doubleValue
+        return lhs + rhs
     }
     
     private func subtract(lhs: Double, rhs: Double) -> Double {
-        return NSDecimalNumber(decimal: (Decimal(lhs) - Decimal(rhs))).doubleValue
+        return lhs - rhs
     }
     
     private func divide(lhs: Double, rhs: Double) -> Double {
-        return NSDecimalNumber(decimal: (Decimal(lhs) / Decimal(rhs))).doubleValue
+        return lhs / rhs
     }
     
     private func multiply(lhs: Double, rhs: Double) -> Double {
-        return NSDecimalNumber(decimal: (Decimal(lhs) * Decimal(rhs))).doubleValue
+        return lhs * rhs
     }
 }


### PR DESCRIPTION
- NSDecimalNumber
고정소숫점 방식인 decimal타입을 이용해서 최대한 오차없는 계산을 가능하게 해줌

- Numberfomatter
maximumFractionDigits 프로퍼티를 사용하여 소수점 15자리에서 반올림되기 때문에 그 이하의 오차에 대해 무시됨. 따라서 이 방식을 채택

- 0을 나눌때 오류를 던지는 곳
더블 타입을 0으로 나누었을 때 에러가 아니라 inf 혹은 nan을 반환하기 때문에 그 결과 값에 대한 처리는 formula 안의 result 메서드에서 해줘야 한다고 판단