### PR TITLE
Formula타입에 대한 수정

### DIFF
--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -19,7 +19,11 @@ struct Formula {
                 throw OperationError.operatorNotEnoughError
             }
             
-            accumulateValue = try operatorsElement.calculate(lhs: accumulateValue, rhs: nextOperand)
+            accumulateValue = operatorsElement.calculate(lhs: accumulateValue, rhs: nextOperand)
+            
+            if accumulateValue.isInfinite || accumulateValue.isNaN {
+                throw OperationError.divideByZeroError
+            }
         }
         
         return accumulateValue


### PR DESCRIPTION
- 0을 나눌때 오류를 던지는 곳
더블 타입을 0으로 나누었을 때 에러가 아니라 inf 혹은 nan을 반환하기 때문에 그 결과 값에 대한 처리는 formula 안의 result 메서드에서 해줘야 한다고 판단