### PR TITLE
String Extension, ExpressionPaser타입에 대한 수정

### DIFF
--- a/Calculator/Calculator/Model/ExtenssionPrimitiveDataType/String.swift
+++ b/Calculator/Calculator/Model/ExtenssionPrimitiveDataType/String.swift
@@ -5,8 +5,6 @@
 //  Created by kangkyungmin on 2023/06/07.
 //
 
-import Foundation
-
 extension String {
     func split(with target: Character) -> [String] {
         return self.components(separatedBy: "\(target)")


### PR DESCRIPTION
- extension String(components)
split을 이용해서 분리해주면 subString타입으로 반환해주기 때문에 다시 String타입으로 변환해줘야하는 components를 사용하면 그 작업을 배제할 수 있기 때문에 components 사용했습니다.

`import Foundation`을 사용하지 않고도 `import Swift`만 선언한 경우에도 `String` 타입은 `components(separatedBy:)` 메서드를 사용가능 합니다. Swift 표준 라이브러리에 `String` 타입의 확장으로 `components(separatedBy:)` 메서드가 구현되어 있기 때문입니다.

- componentsByOperators
고차함수를 활용하여 간결한 코드를 작성하기 위해 reduce를 활용했습니다.

- parse
고차함수를 활용하여 간결한 코드를 작성하기 위해 compactMap를 활용했습니다.